### PR TITLE
Check minimum OS version

### DIFF
--- a/MMMAppUpdater.podspec
+++ b/MMMAppUpdater.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "MMMAppUpdater"
-  s.version          = "0.1.1"
+  s.version          = "0.1.2"
   s.summary          = "Simple pod to check new version of application in Appstore"
   s.description      = "Simple class to check new version of app. You can simply check for new version of the app and open Appstore to let user to update."
   s.homepage         = "https://github.com/martinpilch/MMMAppUpdater"

--- a/Pod/Classes/MMMAppUpdater.m
+++ b/Pod/Classes/MMMAppUpdater.m
@@ -87,7 +87,24 @@ NSString * const kItunesURLKey = @"com.followio.followio.itunes.url";
     
     NSArray *results = info[@"results"];
     NSDictionary *result = (results.count > 0) ? results[0] : nil;
-    BOOL newVersionAvailable = [self compareCurrentVersionWithVersion:result[@"version"]];
+    if (!result) {
+        if (completion) {
+            completion(NO, nil);
+        }
+        return;
+    }
+
+    NSString *minimumOSVersion = result[@"minimumOsVersion"];
+    NSString *currentOSVersion = [NSProcessInfo processInfo].operatingSystemVersionString;
+    if ([currentOSVersion compare:minimumOSVersion options:NSNumericSearch] == NSOrderedAscending) {
+        if (completion) {
+            completion(NO, nil);
+        }
+        return;
+    }
+    
+    NSString *currentVersion = [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"];
+    BOOL newVersionAvailable = ([currentVersion compare:result[@"version"] options:NSNumericSearch] == NSOrderedAscending);
     
     NSString *appItunesPath = [result[@"trackViewUrl"] stringByReplacingOccurrencesOfString:@"&uo=4" withString:@""];
     NSURL *appItunesUrl = [NSURL URLWithString:appItunesPath];
@@ -96,19 +113,6 @@ NSString * const kItunesURLKey = @"com.followio.followio.itunes.url";
     if ( completion ) {
         completion(newVersionAvailable, appItunesUrl);
     }
-}
-
-- (BOOL)compareCurrentVersionWithVersion:(NSString *)latestVersion
-{
-    if ( !latestVersion ) {
-        return NO;
-    }
-    
-    NSDictionary *infoDictionary = [[NSBundle mainBundle]infoDictionary];
-    NSString *currentVersion = infoDictionary[@"CFBundleShortVersionString"];
-    
-    BOOL newVersionAvailable = ![latestVersion isEqualToString:currentVersion];
-    return newVersionAvailable;
 }
 
 @end


### PR DESCRIPTION
The check will not report a new version available if the current OS version is less than the new version minimum OS version. The new version check now uses numeric search ordered ascending so that development versions and versions in app review will no longer report that a new version is available because the current search result version is different.
